### PR TITLE
✨ Auth 모듈 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ out/
 ### VS Code ###
 .vscode/
 
+### envs ###
+.env
+
 ### Java ###
 # Compiled class file
 *.class

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ subprojects {
 		annotationProcessor 'org.projectlombok:lombok:1.18.28'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+		// Spring WebFlux 의존성 추가
+		implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+		implementation 'io.netty:netty-resolver-dns-native-macos:4.1.96.Final:osx-aarch_64'
 	}
 
 

--- a/gitfolio-auth/build.gradle
+++ b/gitfolio-auth/build.gradle
@@ -9,18 +9,25 @@ jar {
 tasks.register("prepareKotlinBuildScriptModel"){}
 
 dependencies {
+    // OAuth 2.0
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // JWT 관련 의존성
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+
+    // Redis 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.0'
 
     // 공통 모듈 추가
     implementation project(":gitfolio-common")

--- a/gitfolio-auth/build.gradle
+++ b/gitfolio-auth/build.gradle
@@ -1,0 +1,31 @@
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
+}
+
+tasks.register("prepareKotlinBuildScriptModel"){}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+
+    // 공통 모듈 추가
+    implementation project(":gitfolio-common")
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gitfolio-auth/gradle/wrapper/gradle-wrapper.properties
+++ b/gitfolio-auth/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/GitfolioAuthApplication.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/GitfolioAuthApplication.java
@@ -1,0 +1,13 @@
+package com.be.gitfolio.auth;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GitfolioAuthApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GitfolioAuthApplication.class, args);
+    }
+
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/config/RedisConfig.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package com.be.gitfolio.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+        return template;
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/config/SecurityConfig.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/config/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.be.gitfolio.auth.config;
+
+import com.be.gitfolio.auth.jwt.CustomLogoutFilter;
+import com.be.gitfolio.auth.jwt.JWTFilter;
+import com.be.gitfolio.auth.jwt.JWTUtil;
+import com.be.gitfolio.auth.oauth2.CustomSuccessHandler;
+import com.be.gitfolio.auth.repository.RedisTokenRepository;
+import com.be.gitfolio.auth.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    private final CustomSuccessHandler customSuccessHandler;
+
+    private final JWTUtil jwtUtil;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           RedisTokenRepository redisTokenRepository) throws Exception {
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //JWTFilter 추가
+        http
+                .addFilterAfter(new JWTFilter(jwtUtil), OAuth2LoginAuthenticationFilter.class);
+
+        //로그아웃
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, redisTokenRepository), LogoutFilter.class);
+        //oauth2
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler));
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/api/auth/reissue").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().authenticated())
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
@@ -1,0 +1,96 @@
+package com.be.gitfolio.auth.controller;
+
+
+import com.be.gitfolio.auth.jwt.JWTUtil;
+import com.be.gitfolio.auth.repository.RedisTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReissueController {
+
+    private final JWTUtil jwtUtil;
+    private final RedisTokenRepository redisTokenRepository;
+
+    @PostMapping("/api/auth/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        // Refresh 토큰 가져오기
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            //response status code
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        // Refresh 토큰 만료 확인
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            //response status code
+            return new ResponseEntity<>("Refresh Token Expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+            //response status code
+            return new ResponseEntity<>("Category is NOT Refresh", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+        Long memberId = jwtUtil.getMemberId(refresh);
+
+        // Redis에서 토큰 존재 여부 확인
+        if (!redisTokenRepository.existsByRefreshToken(username)) {
+            return new ResponseEntity<>("Token is NOT in Redis", HttpStatus.BAD_REQUEST);
+        }
+
+
+
+
+        //make new JWT
+        String newAccess = jwtUtil.createJwt("access", username, role, memberId, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, memberId, 86400000L);
+
+        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+        redisTokenRepository.deleteRefreshToken(refresh);
+        redisTokenRepository.saveRefreshToken(username, newRefresh, 86400000L);
+
+        // 쿠키와 헤더에 토큰 설정
+        response.setHeader("access", newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/CustomOAuth2User.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,49 @@
+package com.be.gitfolio.auth.dto;
+
+import com.be.gitfolio.auth.dto.MemberDTO;
+import com.be.gitfolio.auth.dto.MemberDTO.OAuth2UserDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final OAuth2UserDTO memberDTO;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return memberDTO.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return memberDTO.getName();
+    }
+
+    public String getUsername() {
+        return memberDTO.getUsername();
+    }
+
+    public Long getMemberId() {
+        return memberDTO.getMemberId();
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/GithubResponse.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/GithubResponse.java
@@ -1,0 +1,26 @@
+package com.be.gitfolio.auth.dto;
+
+import java.util.Map;
+
+public class GithubResponse {
+
+    private final Map<String, Object> attribute;
+
+    public GithubResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    public String getGithubId() {
+        return attribute.get("id").toString();
+    }
+
+    // 사용자 이름
+    public String getName() {
+        return (String) attribute.get("login");
+    }
+
+    // 사용자 이메일
+    public String getAvatarUrl() {
+        return (String) attribute.get("avatar_url");
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/MemberDTO.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/dto/MemberDTO.java
@@ -1,0 +1,35 @@
+package com.be.gitfolio.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class MemberDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberSaveRequestDTO {
+        private String role;
+        private String name;
+        private String username;
+        private String avatarUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class OAuth2UserDTO {
+        private Long memberId;
+        private String role;
+        private String name;
+        private String username;
+    }
+
+
+
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/CustomLogoutFilter.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/CustomLogoutFilter.java
@@ -1,0 +1,107 @@
+package com.be.gitfolio.auth.jwt;
+
+import com.be.gitfolio.auth.repository.RedisTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RedisTokenRepository redisTokenRepository;
+
+    public CustomLogoutFilter(JWTUtil jwtUtil, RedisTokenRepository redisTokenRepository) {
+
+        this.jwtUtil = jwtUtil;
+        this.redisTokenRepository = redisTokenRepository;
+    }
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        //path and method verify
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/api\\/auth\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        //refresh null check
+        if (refresh == null) {
+
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = redisTokenRepository.existsByRefreshToken(username);
+        if (!isExist) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        redisTokenRepository.deleteRefreshToken(username);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/JWTFilter.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/JWTFilter.java
@@ -1,0 +1,107 @@
+package com.be.gitfolio.auth.jwt;
+
+import com.be.gitfolio.auth.dto.CustomOAuth2User;
+import com.be.gitfolio.auth.dto.MemberDTO;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static com.be.gitfolio.auth.dto.MemberDTO.*;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String requestUri = request.getRequestURI();
+
+        if (requestUri.matches("^\\/login(?:\\/.*)?$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if (requestUri.matches("^\\/oauth2(?:\\/.*)?$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 헤더에서 access키에 담긴 토큰을 꺼냄
+        String accessToken = request.getHeader("access");
+
+        // 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null) {
+
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        //토큰에서 username과 role 획득
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+        String avatarUrl = jwtUtil.getAvatarUrl(accessToken);
+        Long memberId = jwtUtil.getMemberId(accessToken);
+
+        //userDTO를 생성하여 값 set
+        OAuth2UserDTO memberDTO = OAuth2UserDTO.builder()
+                .username(username)
+                .role(role)
+                .memberId(memberId)
+                .build();
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(memberDTO);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/JWTUtil.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/jwt/JWTUtil.java
@@ -1,0 +1,58 @@
+package com.be.gitfolio.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Long getMemberId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
+    }
+
+    public String getAvatarUrl(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("avatarUrl", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String username, String role, Long memberId, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .claim("memberId", memberId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,62 @@
+package com.be.gitfolio.auth.oauth2;
+
+import com.be.gitfolio.auth.dto.CustomOAuth2User;
+import com.be.gitfolio.auth.jwt.JWTUtil;
+import com.be.gitfolio.auth.repository.RedisTokenRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RedisTokenRepository redisTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        String username = customUserDetails.getUsername();
+        Long memberId = customUserDetails.getMemberId();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        //토큰 생성
+        String refresh = jwtUtil.createJwt("refresh", username, role, memberId,86400000L);
+
+        //Refresh 토큰 저장
+        redisTokenRepository.saveRefreshToken(username, refresh, 86400000L);
+
+        //응답 설정
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
+        response.sendRedirect("http://localhost:5173/chat");
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/repository/RedisTokenRepository.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/repository/RedisTokenRepository.java
@@ -1,0 +1,35 @@
+package com.be.gitfolio.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisTokenRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // Refresh 토큰 저장
+    public void saveRefreshToken(String key, String refreshToken, Long expirationTimeMs) {
+        redisTemplate.opsForValue().set(key, refreshToken, expirationTimeMs, TimeUnit.MILLISECONDS);
+    }
+
+    // Refresh 토큰 조회
+    public String getRefreshToken(String key) {
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    // Refresh 토큰 삭제
+    public void deleteRefreshToken(String key) {
+        redisTemplate.delete(key);
+    }
+
+    // Refresh 토큰 존재 여부 확인
+    public boolean existsByRefreshToken(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/service/CustomOAuth2UserService.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,95 @@
+package com.be.gitfolio.auth.service;
+
+import com.be.gitfolio.auth.dto.CustomOAuth2User;
+import com.be.gitfolio.auth.dto.GithubResponse;
+import com.be.gitfolio.auth.dto.MemberDTO;
+import com.be.gitfolio.common.config.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static com.be.gitfolio.auth.dto.MemberDTO.*;
+
+@Service
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final WebClient webClient;
+
+    public CustomOAuth2UserService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("http://localhost:8081").build();
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("OAuth2User: {}", oAuth2User);
+
+        GithubResponse githubResponse = new GithubResponse(oAuth2User.getAttributes());
+        String username = githubResponse.getGithubId();
+
+        // 회원 조회 및 처리
+        return findMemberIdByUsername(username)
+                .switchIfEmpty(createMemberInMemberModule(createMemberSaveRequest(githubResponse)))
+                .map(memberId -> createCustomOAuth2User(memberId, githubResponse))
+                .block();  // Mono를 동기적으로 처리하여 OAuth2User 반환
+    }
+
+    // 회원 정보 조회를 위한 WebClient 호출 메서드
+    private Mono<Long> findMemberIdByUsername(String username) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/members")
+                        .queryParam("username", username)
+                        .build())
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<BaseResponse<Long>>() {})
+                .flatMap(baseResponse -> {
+                    Long result = baseResponse.getResult();
+                    if (result == null) {
+                        return Mono.empty(); // 회원이 없을 경우 빈 값 반환
+                    }
+                    return Mono.just(result); // 회원 ID가 존재할 경우 반환
+                });
+    }
+
+    // 회원 가입을 위한 WebClient 호출 메서드
+    private Mono<Long> createMemberInMemberModule(MemberSaveRequestDTO memberSaveRequestDTO) {
+        return webClient.post()
+                .uri("/api/members")
+                .bodyValue(memberSaveRequestDTO)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<BaseResponse<Long>>() {})
+                .map(BaseResponse::getResult);
+    }
+
+    // 회원 저장 요청 DTO 생성
+    private MemberSaveRequestDTO createMemberSaveRequest(GithubResponse githubResponse) {
+        // GithubResponse 값 확인
+        log.info("GitHub Response: Username={}, Name={}, AvatarUrl={}", githubResponse.getGithubId(), githubResponse.getName(), githubResponse.getAvatarUrl());
+        return MemberSaveRequestDTO.builder()
+                .username(githubResponse.getGithubId())
+                .name(githubResponse.getName())
+                .role("ROLE_USER")
+                .avatarUrl(githubResponse.getAvatarUrl())
+                .build();
+    }
+
+    // CustomOAuth2User 생성 메서드
+    private CustomOAuth2User createCustomOAuth2User(Long memberId, GithubResponse githubResponse) {
+        OAuth2UserDTO memberDTO = OAuth2UserDTO.builder()
+                .memberId(memberId)
+                .username(githubResponse.getGithubId())
+                .name(githubResponse.getName())
+                .role("ROLE_USER")
+                .build();
+
+        return new CustomOAuth2User(memberDTO);
+    }
+}

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/service/CustomOAuth2UserService.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/service/CustomOAuth2UserService.java
@@ -5,6 +5,7 @@ import com.be.gitfolio.auth.dto.GithubResponse;
 import com.be.gitfolio.auth.dto.MemberDTO;
 import com.be.gitfolio.common.config.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -22,8 +23,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final WebClient webClient;
 
-    public CustomOAuth2UserService(WebClient.Builder webClientBuilder) {
-        this.webClient = webClientBuilder.baseUrl("http://localhost:8081").build();
+    public CustomOAuth2UserService(@Value("${member.server.url}") String memberServerUrl, WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl(memberServerUrl).build();
     }
 
     @Override

--- a/gitfolio-auth/src/main/resources/application.yml
+++ b/gitfolio-auth/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-name: GitHub
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/login/oauth2/code/github"
+            authorization-grant-type: authorization_code
+            scope: read:user
+
+  jwt:
+    secret: ${JWT_SECRET_KEY}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+server:
+  port: 8080

--- a/gitfolio-auth/src/main/resources/application.yml
+++ b/gitfolio-auth/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
   jwt:
     secret: ${JWT_SECRET_KEY}
 
+
   data:
     redis:
       host: ${REDIS_HOST}
@@ -21,3 +22,14 @@ spring:
 
 server:
   port: 8080
+
+jwt:
+  refreshToken:
+    expiry: 86400000
+  accessToken:
+    expiry: 600000
+  redirectUrl: "http://localhost:5173/chat"
+
+member:
+  server:
+    url: http://localhost:8081

--- a/gitfolio-auth/src/test/java/com/be/gitfolio/auth/GitfolioAuthApplicationTests.java
+++ b/gitfolio-auth/src/test/java/com/be/gitfolio/auth/GitfolioAuthApplicationTests.java
@@ -1,0 +1,13 @@
+package com.be.gitfolio.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GitfolioAuthApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/config/WebClientConfig.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.be.gitfolio.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'gitfolio'
 include('gitfolio-common')
+include('gitfolio-auth')


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #11 

## 📝작업 내용

- 깃허브 OAuth2.0을 활용한 소셜 로그인 구현을 완료했습니다.
- 토큰 저장소로 Redis를 사용했습니다.
- 토큰 재발급 로직인 reissue 관련 기능을 구현했습니다.
- 로그아웃 필터를 구현했습니다.
- Member 모듈과의 통신을 위한 WebClient 관련 설정 및 테스트를 완료했습니다.

## 💬리뷰 요구사항

- 로그인은 백엔드로의 별다른 요청이 아닌 하이퍼 링크로 진행됩니다. (ex. "{{base_url}}/oauth2/authorization/github")
- 프론트 개발 시 로그인 성공시 리다이렉트 URL를 설정해야합니다. 지금은 임의의 URL로 설정되어 있습니다.
- 소셜 로그인은 하이퍼링크로 진행되기 때문에 리다이렉트하면서 헤더에 AccessToken을 반환할 수 없으므로, 로그인 성공시 RefreshToken만 쿠키로 전달합니다.
- 쿠키는 httpOnly 설정이 되어있어 js로 직접 조작은 불가합니다. 그래서 백엔드로 reissue 요청을 별도로 보내 헤더에 AccessToken을 담는 과정을 진행해야합니다.
- 흐름은 아래와 같습니다.
  1. 하이퍼 링크를 통한 소셜 로그인 시도
  2. 로그인 성공 시 refreshToken을 쿠키에 담아서 리다이렉트
  3. 프론트에서 쿠키를 담아서 백엔드로 다시 reissue 요청
  4. 백엔드에서 토큰 검증 후 헤더에 AccessToken을 담아서 반환

