### PR TITLE
✨ member 모듈 repo 조회 기능 구현

### DIFF
--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
@@ -2,8 +2,11 @@ package com.be.gitfolio.auth.controller;
 
 
 import com.be.gitfolio.auth.repository.RedisTokenRepository;
+import com.be.gitfolio.common.exception.BaseException;
+import com.be.gitfolio.common.exception.ErrorCode;
 import com.be.gitfolio.common.jwt.JWTUtil;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -38,7 +41,7 @@ public class ReissueController {
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
 
-            if (cookie.getName().equals("refresh")) {
+            if (cookie.getName().equals("refreshToken")) {
 
                 refresh = cookie.getValue();
             }
@@ -46,7 +49,7 @@ public class ReissueController {
 
         if (refresh == null) {
             //response status code
-            return new ResponseEntity<>("Refresh Token null", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("Refresh Token null", HttpStatus.UNAUTHORIZED);
         }
 
         // Refresh 토큰 만료 확인
@@ -54,15 +57,17 @@ public class ReissueController {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
             //response status code
-            return new ResponseEntity<>("Refresh Token Expired", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("Refresh Token Expired", HttpStatus.UNAUTHORIZED);
+        } catch (SignatureException e) {
+            return new ResponseEntity<>("Refresh Signature Does Not Match", HttpStatus.UNAUTHORIZED);
         }
 
         // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
         String category = jwtUtil.getCategory(refresh);
 
         if (!category.equals("refresh")) {
-            //response status code
-            return new ResponseEntity<>("Category is NOT Refresh", HttpStatus.BAD_REQUEST);
+            // response status code
+            return new ResponseEntity<>("Category is NOT Refresh", HttpStatus.UNAUTHORIZED);
         }
 
         String username = jwtUtil.getUsername(refresh);
@@ -72,19 +77,24 @@ public class ReissueController {
 
         // Redis에서 토큰 존재 여부 확인
         if (!redisTokenRepository.existsByRefreshToken(username)) {
-            return new ResponseEntity<>("Token is NOT in Redis", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("Token is NOT in Redis", HttpStatus.UNAUTHORIZED);
         }
 
-        //make new JWT
+        // make new JWT
         String newAccess = jwtUtil.createJwt("access", username, nickname, role, memberId, accessTokenExpiry);
-        String newRefresh = jwtUtil.createJwt("refresh", username, nickname, role, memberId, refreshTokenExpiry);
 
-        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
-        redisTokenRepository.deleteRefreshToken(refresh);
-        redisTokenRepository.saveRefreshToken(username, newRefresh, refreshTokenExpiry);
+        // refreshToken이 만료 기한의 절반보다 적게 남았을때만 재발급
+        if (jwtUtil.isRefreshHaveToReissue(refresh)) {
+            String newRefresh = jwtUtil.createJwt("refresh", username, nickname, role, memberId, refreshTokenExpiry);
 
-        // 쿠키와 헤더에 토큰 설정
-        response.addCookie(createCookie("refresh", newRefresh));
+            //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+            redisTokenRepository.deleteRefreshToken(refresh);
+            redisTokenRepository.saveRefreshToken(username, newRefresh, refreshTokenExpiry);
+
+            // 쿠키와 헤더에 토큰 설정
+            response.addCookie(createCookie("refreshToken", newRefresh));
+        }
+
 
         // AccessToken을 body에 담아서 반환
         HashMap<String, String> tokens = new HashMap<>();

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
@@ -66,6 +66,7 @@ public class ReissueController {
         }
 
         String username = jwtUtil.getUsername(refresh);
+        String nickname = jwtUtil.getNickname(refresh);
         String role = jwtUtil.getRole(refresh);
         Long memberId = jwtUtil.getMemberId(refresh);
 
@@ -75,8 +76,8 @@ public class ReissueController {
         }
 
         //make new JWT
-        String newAccess = jwtUtil.createJwt("access", username, role, memberId, accessTokenExpiry);
-        String newRefresh = jwtUtil.createJwt("refresh", username, role, memberId, refreshTokenExpiry);
+        String newAccess = jwtUtil.createJwt("access", username, nickname, role, memberId, accessTokenExpiry);
+        String newRefresh = jwtUtil.createJwt("refresh", username, nickname, role, memberId, refreshTokenExpiry);
 
         //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
         redisTokenRepository.deleteRefreshToken(refresh);
@@ -87,7 +88,7 @@ public class ReissueController {
 
         // AccessToken을 body에 담아서 반환
         HashMap<String, String> tokens = new HashMap<>();
-        tokens.put("access", newAccess);
+        tokens.put("accessToken", newAccess);
 
         return new ResponseEntity<>(tokens, HttpStatus.OK);
     }

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
@@ -38,6 +38,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         //OAuth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
         String username = customUserDetails.getUsername();
+        String nickname = customUserDetails.getName();
         Long memberId = customUserDetails.getMemberId();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -46,7 +47,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String role = auth.getAuthority();
 
         //토큰 생성
-        String refresh = jwtUtil.createJwt("refresh", username, role, memberId,refreshTokenExpiry);
+        String refresh = jwtUtil.createJwt("refresh", username, nickname, role, memberId,refreshTokenExpiry);
 
         //Refresh 토큰 저장
         redisTokenRepository.saveRefreshToken(username, refresh, refreshTokenExpiry);

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/oauth2/CustomSuccessHandler.java
@@ -53,7 +53,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         redisTokenRepository.saveRefreshToken(username, refresh, refreshTokenExpiry);
 
         //응답 설정
-        response.addCookie(createCookie("refresh", refresh));
+        response.addCookie(createCookie("refreshToken", refresh));
         response.setStatus(HttpStatus.OK.value());
         response.sendRedirect(redirectUrl);
     }

--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/aop/AuthAspect.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/aop/AuthAspect.java
@@ -31,12 +31,15 @@ public class AuthAspect {
         HttpServletRequest request = Objects.requireNonNull(attributes, "attributes must not be null").getRequest();
 
         // 헤더에서 AccessToken 추출
-        String accessToken = request.getHeader("access");
+        String authorizationHeader = request.getHeader("Authorization");
 
-        // 토큰이 없거나 빈 값인지 검사
-        if (accessToken == null || accessToken.isEmpty()) {
+        // Authorization 헤더가 존재하는지, 그리고 Bearer로 시작하는지 확인
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
             throw new BaseException(ErrorCode.TOKEN_IS_MISSING);
         }
+
+        // Bearer를 제거하고 실제 accessToken만 추출
+        String accessToken = authorizationHeader.substring(7);
 
         // 토큰이 만료되었는지 검사
         try {
@@ -54,7 +57,9 @@ public class AuthAspect {
 
         // 토큰에서 사용자 정보 추출 후 request에 추가
         Long memberId = jwtUtil.getMemberId(accessToken);
+        String nickname = jwtUtil.getNickname(accessToken);
         request.setAttribute("memberId", memberId);
+        request.setAttribute("nickname", nickname);
         log.info("Authenticated Member ID : {}", memberId);
     }
 }

--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/jwt/JWTUtil.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/jwt/JWTUtil.java
@@ -26,6 +26,10 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
     }
 
+    public String getNickname(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("nickname", String.class);
+    }
+
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
     }
@@ -38,11 +42,12 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String category, String username, String role, Long memberId, Long expiredMs) {
+    public String createJwt(String category, String username, String nickname, String role, Long memberId, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("category", category)
                 .claim("username", username)
+                .claim("nickname", nickname)
                 .claim("role", role)
                 .claim("memberId", memberId)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/controller/MemberController.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/controller/MemberController.java
@@ -6,12 +6,15 @@ import com.be.gitfolio.member.domain.Member;
 import com.be.gitfolio.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.be.gitfolio.member.dto.MemberRequestDTO.*;
 import static com.be.gitfolio.member.dto.MemberResponseDTO.*;
@@ -19,10 +22,10 @@ import static com.be.gitfolio.member.dto.MemberResponseDTO.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Slf4j
 public class MemberController {
 
     private final MemberService memberService;
-
 
     /**
      * 회원 생성
@@ -65,13 +68,25 @@ public class MemberController {
      */
     @AuthRequired
     @PutMapping("/me")
-    public ResponseEntity<BaseResponse<String>> updateMemberBasicInfo(HttpServletRequest request,
-                                                                      @RequestPart("memberUpdateRequestDTO") MemberUpdateRequestDTO memberUpdateRequestDTO,
-                                                                      @RequestPart("memberAdditionalRequestDTO") MemberAdditionalRequestDTO memberAdditionalRequestDTO,
-                                                                      @RequestPart("imageFile") MultipartFile imageFile) throws IOException {
+    public ResponseEntity<BaseResponse<String>> updateMemberBasicInfo(
+            HttpServletRequest request,
+            @RequestPart("memberUpdateRequestDTO") MemberUpdateRequestDTO memberUpdateRequestDTO,
+            @RequestPart("memberAdditionalRequestDTO") MemberAdditionalRequestDTO memberAdditionalRequestDTO,
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
 
         Long memberId = (Long) request.getAttribute("memberId");
         memberService.updateMemberInfo(memberId, memberUpdateRequestDTO, memberAdditionalRequestDTO, imageFile);
         return ResponseEntity.ok().body(new BaseResponse<>("회원 기본 정보 수정이 완료되었습니다."));
+    }
+
+    /**
+     * 회원 레포 조회
+     */
+    @AuthRequired
+    @GetMapping("/myRepo")
+    public ResponseEntity<BaseResponse<List<MemberGithubRepositoryDTO>>> getUserRepositoriesWithLanguages(HttpServletRequest request) {
+        String username = String.valueOf(request.getAttribute("nickname"));
+        log.info("사용자 아이디 : {}", username);
+        return ResponseEntity.ok().body(new BaseResponse<>(memberService.getUserRepositoriesWithLanguages(username)));
     }
 }

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/dto/MemberResponseDTO.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/dto/MemberResponseDTO.java
@@ -53,4 +53,17 @@ public class MemberResponseDTO {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberGithubRepositoryDTO {
+        private Long repoId;
+        private String repoName;
+        private String repoUrl;
+        private String topLanguage;
+        private String updatedAt;
+    }
+
 }

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberService.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberService.java
@@ -5,31 +5,48 @@ import com.be.gitfolio.common.exception.ErrorCode;
 import com.be.gitfolio.common.s3.S3Service;
 import com.be.gitfolio.member.domain.Member;
 import com.be.gitfolio.member.domain.MemberAdditionalInfo;
-import com.be.gitfolio.member.dto.MemberRequestDTO;
-import com.be.gitfolio.member.dto.MemberResponseDTO;
 import com.be.gitfolio.member.repository.MemberAdditionalInfoRepository;
 import com.be.gitfolio.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.be.gitfolio.member.dto.MemberRequestDTO.*;
 import static com.be.gitfolio.member.dto.MemberResponseDTO.*;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 @Transactional(readOnly = true)
 public class MemberService {
 
+    @Value(("${github.api.token}"))
+    private String GITHUB_API_TOKEN;
+
+
     private final MemberRepository memberRepository;
     private final MemberAdditionalInfoRepository memberAdditionalInfoRepository;
     private final S3Service s3Service;
+    private final WebClient webClient;
+
+    public MemberService(MemberRepository memberRepository,
+                         MemberAdditionalInfoRepository memberAdditionalInfoRepository,
+                         S3Service s3Service,
+                         @Value("${github.api.url}") String url, WebClient.Builder webClientBuilder) {
+        this.memberRepository = memberRepository;
+        this.memberAdditionalInfoRepository = memberAdditionalInfoRepository;
+        this.s3Service = s3Service;
+        this.webClient = webClientBuilder.baseUrl(url).build();
+    }
 
     /**
      * 회원 생성
@@ -54,34 +71,6 @@ public class MemberService {
         return memberRepository.findByUsername(username);
     }
 
-//    /**
-//     * 회원 추가 정보 생성
-//     */
-//    @Transactional
-//    public String createMemberAdditionalInfo(Long memberId, MemberAdditionalRequestDTO memberAdditionalRequestDTO) {
-//        Optional<MemberAdditionalInfo> memberAdditionalInfoOpt = memberAdditionalInfoRepository.findByMemberId(memberId.toString());
-//
-//        if (memberAdditionalInfoOpt.isPresent()) {
-//            throw new BaseException(ErrorCode.ALREADY_EXIST_MEMBER_ADDITIONAL_INFO);
-//        }
-//
-//        MemberAdditionalInfo memberAdditionalInfo = MemberAdditionalInfo.of(memberId, memberAdditionalRequestDTO);
-//        MemberAdditionalInfo savedMemberAdditionalInfo = memberAdditionalInfoRepository.save(memberAdditionalInfo);
-//        return savedMemberAdditionalInfo.getId();
-//    }
-
-//    /**
-//     * 회원 추가 정보 수정
-//     */
-//    @Transactional
-//    public void updateMemberAdditionalInfo(Long memberId, MemberAdditionalRequestDTO memberAdditionalRequestDTO) {
-//        MemberAdditionalInfo memberAdditionalInfo = memberAdditionalInfoRepository.findByMemberId(memberId.toString())
-//                .orElseThrow(() -> new BaseException(ErrorCode.NO_MEMBER_ADDITIONAL_INFO));
-//
-//        memberAdditionalInfo.updateMemberAdditionalInfo(memberAdditionalRequestDTO);
-//        memberAdditionalInfoRepository.save(memberAdditionalInfo);
-//    }
-
 
     /**
      * 회원 정보 상세 조회
@@ -94,7 +83,8 @@ public class MemberService {
         Optional<MemberAdditionalInfo> additionalInfoOpt = memberAdditionalInfoRepository.findByMemberId(member.getId().toString());
 
         // 추가 정보가 없으면 기본값으로 처리
-        MemberAdditionalInfo additionalInfo = additionalInfoOpt.orElseGet(() -> MemberAdditionalInfo.from(member.getId()));
+        MemberAdditionalInfo additionalInfo = additionalInfoOpt
+                .orElseGet(() -> MemberAdditionalInfo.from(member.getId()));
 
         // DTO에 MySQL과 MongoDB 데이터를 함께 담아 반환
         return MemberDetailDTO.of(member, additionalInfo);
@@ -104,17 +94,26 @@ public class MemberService {
      * 회원 기본 정보 수정
      */
     @Transactional
-    public void updateMemberInfo(Long memberId, MemberUpdateRequestDTO memberUpdateRequestDTO, MemberAdditionalRequestDTO memberAdditionalRequestDTO, MultipartFile imageFile) throws IOException {
+    public void updateMemberInfo(Long memberId,
+                                 MemberUpdateRequestDTO memberUpdateRequestDTO,
+                                 MemberAdditionalRequestDTO memberAdditionalRequestDTO,
+                                 MultipartFile imageFile) throws IOException {
         // 기본 정보 수정
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NO_MEMBER_INFO));
 
-        String imageUrl = member.getAvatarUrl();
-        if (!imageUrl.contains("avatars.githubusercontent.com")) {
-            s3Service.deleteFile(imageUrl);
-        }
+        String avatarUrl = member.getAvatarUrl();
 
-        String avatarUrl = s3Service.uploadFile(imageFile);
+        // 이미지 파일이 있을 경우에만 업로드 진행
+        if (imageFile != null && !imageFile.isEmpty()) {
+            // 기존 이미지가 깃허브 기본 이미지가 아니면 삭제
+            if (avatarUrl != null && !avatarUrl.contains("avatars.githubusercontent.com")) {
+                s3Service.deleteFile(avatarUrl);
+            }
+
+            // 새 이미지 업로드
+            avatarUrl = s3Service.uploadFile(imageFile);
+        }
 
         member.updateMember(memberUpdateRequestDTO, avatarUrl);
         memberRepository.save(member);
@@ -126,4 +125,28 @@ public class MemberService {
         memberAdditionalInfo.updateMemberAdditionalInfo(memberAdditionalRequestDTO);
         memberAdditionalInfoRepository.save(memberAdditionalInfo);
     }
+
+    /**
+     * 레포지토리 목록과 각 레포지토리의 주 언어 정보를 가져오는 메서드
+     */
+    public List<MemberGithubRepositoryDTO> getUserRepositoriesWithLanguages(String username) {
+        return webClient.get()
+                .uri("/users/{username}/repos", username)
+                .header("Authorization", "Bearer " + GITHUB_API_TOKEN)
+                .retrieve()
+                .bodyToFlux(Map.class)  // JSON 응답을 Map으로 받음
+                .map(repo -> MemberGithubRepositoryDTO.builder()
+                            .repoName((String) repo.get("name"))
+                            .repoUrl((String) repo.get("html_url"))  // URL 필드는 "html_url"에 존재
+                            .repoId(Long.valueOf((Integer) repo.get("id")))
+                            .updatedAt((String) repo.get("updated_at"))
+                            .topLanguage((String) repo.get("language"))
+                            .build()
+                )
+                .collectList()
+                .block();  // 블로킹 방식으로 List 반환
+    }
+
+
+
 }

--- a/gitfolio-member/src/main/resources/application.yml
+++ b/gitfolio-member/src/main/resources/application.yml
@@ -41,6 +41,11 @@ cloud:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
 
+github:
+  api:
+    url: https://api.github.com
+    token: ${GITHUB_API_TOKEN}
+
 server:
   port: 8081
 grpc:

--- a/gitfolio-member/src/main/resources/application.yml
+++ b/gitfolio-member/src/main/resources/application.yml
@@ -46,6 +46,10 @@ github:
     url: https://api.github.com
     token: ${GITHUB_API_TOKEN}
 
+jwt:
+  refreshToken:
+    expiry: 86400000
+
 server:
   port: 8081
 grpc:

--- a/gitfolio-resume/src/main/resources/application.yml
+++ b/gitfolio-resume/src/main/resources/application.yml
@@ -41,6 +41,9 @@ cloud:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
 
+jwt:
+  refreshToken:
+    expiry: 86400000
 
 
 server:


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #23 

## 📝작업 내용

- accessToken을 발급할때 key값을 기존 "access"에서 "accessToken"으로 수정했습니다.
- AOP에서 accessToken을 받아서 확인할때 "Authorization" : "Bearer ${accessToken}"으로 헤더에 담도록 수정했습니다.
- Member 모듈에서 사용자의 Github Repository를 전부 조회하는 기능을 만들었습니다.
- 레포 조회시 가장 많이 사용한 언어가 null 이면 md파일로만 구성되어 있거나 코드작성이 없는 파일인 경우입니다. (ex. 아래 이미지처럼 되어있는 경우)

### 스크린샷 (선택)
<img width="1318" alt="스크린샷 2024-10-23 13 30 55" src="https://github.com/user-attachments/assets/14b2e51b-02a1-4eab-b052-4079f4f28da0">
<img width="1010" alt="스크린샷 2024-10-23 13 31 06" src="https://github.com/user-attachments/assets/189b177f-c375-4629-8a52-7688ec3b6205">
