### PR TITLE
🎨 댓글 조회시 사용자 정보 포함하도록 수정

### DIFF
--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ResumeResponseDTO {
@@ -127,13 +128,21 @@ public class ResumeResponseDTO {
         private Long id;
         private String resumeId;
         private Long memberId;
+        private String nickname;
+        private String avatarUrl;
         private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
 
-        public CommentResponseDTO(Comment comment) {
+        public CommentResponseDTO(Comment comment, String nickname, String avatarUrl) {
             this.id = comment.getId();
             this.resumeId = comment.getResumeId();
             this.memberId = comment.getMemberId();
+            this.nickname = nickname;
+            this.avatarUrl = avatarUrl;
             this.content = comment.getContent();
+            this.createdAt = comment.getCreatedAt();
+            this.updatedAt = comment.getUpdatedAt();
         }
     }
 

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/CommentService.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/CommentService.java
@@ -1,7 +1,9 @@
 package com.be.gitfolio.resume.service;
 
+import com.be.gitfolio.common.client.MemberGrpcClient;
 import com.be.gitfolio.common.exception.BaseException;
 import com.be.gitfolio.common.exception.ErrorCode;
+import com.be.gitfolio.common.grpc.MemberServiceProto;
 import com.be.gitfolio.resume.domain.Comment;
 import com.be.gitfolio.resume.dto.ResumeRequestDTO;
 import com.be.gitfolio.resume.dto.ResumeResponseDTO;
@@ -24,7 +26,7 @@ import static com.be.gitfolio.resume.dto.ResumeResponseDTO.*;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-
+    private final MemberGrpcClient memberGrpcClient;
 
     /**
      * 댓글 작성
@@ -76,7 +78,10 @@ public class CommentService {
     public List<CommentResponseDTO> getCommentList(String resumeId) {
         List<Comment> comments = commentRepository.findAllByResumeId(resumeId);
         return comments.stream()
-                .map(CommentResponseDTO::new)
-                .collect(Collectors.toList());
+                .map(comment -> {
+                    MemberServiceProto.MemberResponseById memberResponse = memberGrpcClient.getMember(String.valueOf(comment.getMemberId()));
+                    return new CommentResponseDTO(comment, memberResponse.getNickname(), memberResponse.getAvatarUrl());
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #39 

## 📝작업 내용

- 이력서별 댓글 조회시 사용자 관련 정보를 포함해 반환하도록 수정했습니다.
- 추가된 필드는 사용자 닉네임, 사용자 프로필, 생성일자, 수정일자 입니다.

