### PR TITLE
✨ 좋아요한 이력서만 보기 구현

### DIFF
--- a/gitfolio-chat/src/main/java/com/be/gitfolio/chat/controller/ChatController.java
+++ b/gitfolio-chat/src/main/java/com/be/gitfolio/chat/controller/ChatController.java
@@ -20,7 +20,7 @@ import static com.be.gitfolio.chat.dto.MessageResponseDTO.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/chat")
+@RequestMapping("/api/chats")
 @Slf4j
 public class ChatController {
 

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
@@ -4,6 +4,7 @@ import com.be.gitfolio.common.aop.AuthRequired;
 import com.be.gitfolio.common.config.BaseResponse;
 import com.be.gitfolio.resume.service.CommentService;
 import com.be.gitfolio.resume.service.ResumeService;
+import jakarta.persistence.OptimisticLockException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static com.be.gitfolio.resume.dto.ResumeRequestDTO.*;
 import static com.be.gitfolio.resume.dto.ResumeResponseDTO.*;
@@ -54,6 +57,7 @@ public class ResumeController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "recent") String sortOrder,
+            @RequestParam(required = false) Boolean liked,
             @RequestHeader(value = "Authorization", required = false) String token
     ) {
         ResumeFilterDTO resumeFilterDTO = new ResumeFilterDTO(
@@ -62,6 +66,7 @@ public class ResumeController {
                 techStack,
                 schoolType,
                 sortOrder,
+                liked,
                 page,
                 size
         );
@@ -140,6 +145,25 @@ public class ResumeController {
             return ResponseEntity.ok().body(new BaseResponse<>("좋아요 상태가 변경되었습니다."));
         }
     }
+
+    /**
+     * 좋아요 기능 동시성 테스트용
+     */
+//    @PostMapping("{resumeId}/members/{memberId}/likes")
+//    public ResponseEntity<BaseResponse<String>> toggleLike(@PathVariable("resumeId") String resumeId,
+//                                                           @PathVariable("memberId") Long memberId) {
+//        try {
+//            boolean liked = resumeService.toggleLike(resumeId, memberId);
+//            if (liked) {
+//                return ResponseEntity.ok().body(new BaseResponse<>("좋아요가 추가되었습니다."));
+//            } else {
+//                return ResponseEntity.ok().body(new BaseResponse<>("좋아요 상태가 변경되었습니다."));
+//            }
+//        } catch (OptimisticLockException e) {
+//            return ResponseEntity.status(HttpStatus.CONFLICT)
+//                    .body(new BaseResponse<>("동시에 많은 요청이 발생했습니다. 다시 시도해 주세요."));
+//        }
+//    }
 
     /**
      * 댓글 작성

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
@@ -67,6 +67,7 @@ public class ResumeRequestDTO {
             String techStack, // 기술 스택별
             String schoolType, // 학력별
             String sortOrder, // 정렬기준
+            Boolean liked, // 좋아요 필터링
             @Min(0) int page,
             @Min(0) int size
     ) {

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
@@ -6,6 +6,7 @@ import com.be.gitfolio.resume.domain.Resume;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -54,6 +55,15 @@ public class ResumeResponseDTO {
                     page.getTotalElements(),
                     page.getSize(),
                     page.getContent()
+            );
+        }
+        public PaginationResponseDTO(List<T> content, long totalElements, Pageable pageable) {
+            this(
+                    pageable.getPageNumber(),
+                    (int) Math.ceil((double) totalElements / pageable.getPageSize()),
+                    totalElements,
+                    pageable.getPageSize(),
+                    content
             );
         }
     }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/LikeRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/LikeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -13,4 +14,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByResumeIdAndMemberId(String resumeId, Long memberId);
 
     void deleteLikesByResumeId(String resumeId);
+
+    @Query("SELECT l.resumeId FROM Like l WHERE l.memberId = :memberId AND l.status = true")
+    List<String> findLikedResumeIdsByMemberId(Long memberId);
+
+    @Query("SELECT l FROM Like l WHERE l.memberId = :memberId AND l.resumeId IN :resumeIds")
+    List<Like> findLikesByMemberIdAndResumeIds(Long memberId, List<String> resumeIds);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepository.java
@@ -1,9 +1,6 @@
 package com.be.gitfolio.resume.repository;
 
 import com.be.gitfolio.resume.domain.Resume;
-import com.be.gitfolio.resume.dto.ResumeRequestDTO;
-import com.mongodb.client.MongoIterable;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryCustom.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryCustom.java
@@ -4,8 +4,10 @@ import com.be.gitfolio.resume.domain.Resume;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 import static com.be.gitfolio.resume.dto.ResumeRequestDTO.*;
 
 public interface ResumeRepositoryCustom {
-    Page<Resume> findResumeByFilter(ResumeFilterDTO resumeFilterDTO, Pageable pageable);
+    Page<Resume> findResumeByFilter(ResumeFilterDTO resumeFilterDTO, List<String> likedResumeId, Pageable pageable);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryImpl.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public Page<Resume> findResumeByFilter(ResumeRequestDTO.ResumeFilterDTO resumeFilterDTO, Pageable pageable) {
+    public Page<Resume> findResumeByFilter(ResumeRequestDTO.ResumeFilterDTO resumeFilterDTO, List<String> likedResumeIds, Pageable pageable) {
         Query query = new Query();
 
         // 동적 필터 적용
@@ -50,6 +50,10 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                 default -> {
                 }
             }
+        }
+
+        if (likedResumeIds != null) {
+            query.addCriteria(Criteria.where("_id").in(likedResumeIds));
         }
 
         // 페이징 처리

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/ResumeService.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/ResumeService.java
@@ -6,22 +6,23 @@ import com.be.gitfolio.common.exception.ErrorCode;
 import com.be.gitfolio.common.jwt.JWTUtil;
 import com.be.gitfolio.common.s3.S3Service;
 import com.be.gitfolio.common.type.NotificationType;
-import com.be.gitfolio.common.type.PositionType;
 import com.be.gitfolio.resume.domain.Like;
 import com.be.gitfolio.resume.domain.Resume;
 import com.be.gitfolio.resume.event.ResumeEventPublisher;
 import com.be.gitfolio.resume.mapper.MemberInfoMapper;
-import com.be.gitfolio.resume.mapper.MemberMapper;
 import com.be.gitfolio.resume.repository.CommentRepository;
 import com.be.gitfolio.resume.repository.LikeRepository;
 import com.be.gitfolio.resume.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,10 +31,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.be.gitfolio.common.grpc.MemberServiceProto.*;
 import static com.be.gitfolio.resume.dto.ResumeRequestDTO.*;
@@ -55,6 +56,7 @@ public class ResumeService {
     private final ResumeEventPublisher resumeEventPublisher;
     private final MemberInfoMapper memberInfoMapper;
     private final S3Service s3Service;
+    private final MongoTemplate mongoTemplate;
 
     /**
      * 이력서 생성 요청
@@ -93,10 +95,32 @@ public class ResumeService {
 
         Pageable pageable = PageRequest.of(resumeFilterDTO.page(), resumeFilterDTO.size());
 
-        Page<ResumeListDTO> resumePage = resumeRepository.findResumeByFilter(resumeFilterDTO, pageable)
+        // 1. MySQL에서 사용자가 좋아요 누른 이력서 ID 목록 조회
+        List<String> likedResumeIds = null;
+        if (Boolean.TRUE.equals(resumeFilterDTO.liked())) {
+            likedResumeIds = likeRepository.findLikedResumeIdsByMemberId(memberId);
+            // 좋아요 목록 비어있으면 빈 페이지 반환
+            if (likedResumeIds.isEmpty()) {
+                return new PaginationResponseDTO<>(List.of(), 0, pageable);
+            }
+        }
+
+        // 2. MongoDB에서 이력서 목록 조회
+        Page<Resume> resumePage = resumeRepository.findResumeByFilter(resumeFilterDTO, likedResumeIds, pageable);
+
+        // 3. MySQL에서 사용자가 좋아요 누른 상태를 한 번에 조회하고 Map으로 변환
+        List<Like> likes = likeRepository
+                .findLikesByMemberIdAndResumeIds(memberId, resumePage.stream().map(Resume::getId).toList());
+
+        // List<Like>를 Map<String, Boolean>으로 변환
+        Map<String, Boolean> likedStatusMap = likes.stream()
+                .collect(Collectors.toMap(Like::getResumeId, Like::getStatus));
+
+
+        // 4. 이력서 목록을 DTO로 변환
+        List<ResumeListDTO> resumeListDTOs = resumePage.stream()
                 .map(resume -> {
-                    Optional<Like> likeOpt = likeRepository.findByResumeIdAndMemberId(resume.getId(), memberId);
-                    boolean isLiked = likeOpt.isPresent() && likeOpt.get().getStatus().equals(Boolean.TRUE);
+                    boolean isLiked = likedStatusMap.getOrDefault(resume.getId(), false);
 
                     // Avatar URL 가공
                     String avatarUrl = resume.getAvatarUrl();
@@ -105,9 +129,10 @@ public class ResumeService {
                     }
 
                     return new ResumeListDTO(resume, isLiked, avatarUrl);
-                });
+                })
+                .toList();
 
-        return new PaginationResponseDTO<>(resumePage);
+        return new PaginationResponseDTO<>(resumeListDTOs, resumePage.getTotalElements(), pageable);
     }
 
     // Optional한 memberId 처리 함수
@@ -217,7 +242,6 @@ public class ResumeService {
 
             // 1시간 동안 조회수 증가 안되도록 설정
             redisTemplate.opsForValue().set(redisKey, "1", 1, TimeUnit.HOURS);
-            log.info("New Viewer : {}", clientIp);
         }
     }
 
@@ -226,36 +250,45 @@ public class ResumeService {
      */
     @Transactional
     public boolean toggleLike(String resumeId, Long memberId) {
+
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(() -> new BaseException(ErrorCode.RESUME_NOT_FOUND));
 
-        // 좋아요 상태를 확인하고, 상태에 따라 처리
         Optional<Like> existingLikeOpt = likeRepository.findByResumeIdAndMemberId(resumeId, memberId);
-        boolean isLikeAdded = existingLikeOpt
-                .map(existingLike -> {
-                    existingLike.updateStatus();
-                    if (Boolean.TRUE.equals(existingLike.getStatus())) {
-                        resume.increaseLike();
-                        // 이벤트 발행
-                        resumeEventPublisher.publishResumeEvent(memberId, Long.valueOf(resume.getMemberId()), resumeId, NotificationType.LIKE);
-                    } else {
-                        resume.decreaseLike();
-                    }
-                    return false; // 좋아요 취소됨
-                })
-                .orElseGet(() -> {
-                    Like newLike = Like.of(resumeId, memberId);
-                    resume.increaseLike();
-                    likeRepository.save(newLike);
-                    // 이벤트 발행
-                    resumeEventPublisher.publishResumeEvent(memberId, Long.valueOf(resume.getMemberId()), resumeId, NotificationType.LIKE);
-                    return true; // 새로운 좋아요 추가됨
-                });
 
-        // 좋아요 수 업데이트 및 상태 저장
-        resumeRepository.save(resume);
-        existingLikeOpt.ifPresent(likeRepository::save);
+        return existingLikeOpt.map(existingLike -> {
+            existingLike.updateStatus();
+            if (Boolean.TRUE.equals(existingLike.getStatus())) {
+                increaseLikeCount(resumeId);
+                resumeEventPublisher.publishResumeEvent(memberId, Long.valueOf(resume.getMemberId()), resumeId, NotificationType.LIKE);
+            } else {
+                decreaseLikeCount(resumeId);
+            }
+            return false;
+        }).orElseGet(() -> {
+            Like newLike = Like.of(resumeId, memberId);
+            increaseLikeCount(resumeId);
+            likeRepository.save(newLike);
+            resumeEventPublisher.publishResumeEvent(memberId, Long.valueOf(resume.getMemberId()), resumeId, NotificationType.LIKE);
+            return true;
+        });
+    }
 
-        return isLikeAdded;
+    /**
+     * 좋아요 수 증가 (MongoTemplate 활용)
+     */
+    private void increaseLikeCount(String resumeId) {
+        Query query = new Query(Criteria.where("_id").is(resumeId));
+        Update update = new Update().inc("likeCount", 1);
+        mongoTemplate.findAndModify(query, update, Resume.class);
+    }
+
+    /**
+     * 좋아요 수 감소 (MongoTemplate 활용)
+     */
+    private void decreaseLikeCount(String resumeId) {
+        Query query = new Query(Criteria.where("_id").is(resumeId));
+        Update update = new Update().inc("likeCount", -1);
+        mongoTemplate.findAndModify(query, update, Resume.class);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #57 

## 📝작업 내용

- 좋아요한 이력서만 보는 기능을 추가했습니다.
- 따로 엔드포인트를 만든게 아니라 기존 전체 조회에 파라미터를 추가했습니다.
- 검색 필터에 liked 라는 파라미터를 추가했고 해당 파라미터를 true로 넣고 보내면 됩니다.
- 다른 필터들과 동일하게 필요할때만 해당 파라미터를 넣으면 됩니다.

### 스크린샷
<img width="1288" alt="스크린샷 2024-11-10 00 09 14" src="https://github.com/user-attachments/assets/495cce97-d88a-4563-8696-11d8f5313b31">


