### PR TITLE
🎨 이미지 삭제로직 제거

### DIFF
--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberService.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberService.java
@@ -119,11 +119,6 @@ public class MemberService {
 
         // 이미지 파일이 있을 경우에만 업로드 진행
         if (imageFile != null && !imageFile.isEmpty()) {
-            // 기존 이미지가 깃허브 기본 이미지가 아니면 삭제
-            if (avatarUrl != null && !avatarUrl.contains("avatars.githubusercontent.com")) {
-                s3Service.deleteFile(avatarUrl);
-            }
-
             // 새 이미지 업로드
             avatarUrl = s3Service.uploadFile(imageFile);
         }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/ResumeService.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/ResumeService.java
@@ -214,10 +214,6 @@ public class ResumeService {
         String avatarUrl = resume.getAvatarUrl();
 
         if (imageFile != null && !imageFile.isEmpty()) {
-            if (avatarUrl != null && !avatarUrl.contains("avatars.githubusercontent.com")) {
-                s3Service.deleteFile(avatarUrl);
-            }
-
             avatarUrl = s3Service.uploadFile(imageFile);
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #67 

## 📝작업 내용

- 이미지 변경 시 s3에서 삭제하던 로직을 제거해 과거 이력서에서 사용한 이미지를 계속 쓸 수 있도록 했습니다.


