### PR TITLE
✨ 이력서 공개 여부필드 추가

### DIFF
--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/type/Visibility.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/type/Visibility.java
@@ -1,0 +1,5 @@
+package com.be.gitfolio.common.type;
+
+public enum Visibility {
+    PUBLIC, PRIVATE
+}

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/domain/Resume.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/domain/Resume.java
@@ -4,6 +4,8 @@ import com.be.gitfolio.common.config.BaseEntityMongo;
 import com.be.gitfolio.common.type.*;
 import com.be.gitfolio.resume.dto.ResumeRequestDTO;
 import com.be.gitfolio.resume.dto.ResumeResponseDTO;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +27,7 @@ public class Resume extends BaseEntityMongo {
 
     @Id
     private String id;  // 이력서 ID
-    private String memberId;  // 회원 ID
+    private Long memberId;  // 회원 ID
     private String memberName; // 회원 이름
     private String avatarUrl; // 프로필 사진
     private String phoneNumber; // 전화번호
@@ -39,20 +41,19 @@ public class Resume extends BaseEntityMongo {
     private List<Link> links;  // 개인 링크
     private List<Education> educations;  // 학력
     private List<Certificate> certificates;  // 자격증
+    @Enumerated(EnumType.STRING)
+    private Visibility visibility; // 공개 여부
     private int likeCount;  // 좋아요 수
     private int viewCount;  // 조회수
+
+    public void updateVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
 
     public void updateView() {
         this.viewCount++;
     }
 
-    public void increaseLike() {
-        this.likeCount++;
-    }
-
-    public void decreaseLike() {
-        this.likeCount--;
-    }
     public void updateResume(UpdateResumeRequestDTO updateResumeDTO, String avatarUrl) {
         this.avatarUrl = avatarUrl;
         this.techStack = updateResumeDTO.techStack();
@@ -65,9 +66,9 @@ public class Resume extends BaseEntityMongo {
         this.certificates = updateResumeDTO.certificates();
     }
 
-    public static Resume of(MemberInfoDTO memberInfoDTO, AIResponseDTO aiResponseDTO) {
+    public static Resume of(MemberInfoDTO memberInfoDTO, AIResponseDTO aiResponseDTO, Visibility visibility) {
         return Resume.builder()
-                .memberId(String.valueOf(memberInfoDTO.memberId()))
+                .memberId(memberInfoDTO.memberId())
                 .memberName(memberInfoDTO.name())
                 .avatarUrl(memberInfoDTO.avatarUrl())
                 .phoneNumber(memberInfoDTO.phoneNumber())
@@ -80,6 +81,7 @@ public class Resume extends BaseEntityMongo {
                 .links(memberInfoDTO.links())
                 .educations(memberInfoDTO.educations())
                 .certificates(memberInfoDTO.certificates())
+                .visibility(visibility)
                 .likeCount(0)
                 .viewCount(0)
                 .build();

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
@@ -1,6 +1,7 @@
 package com.be.gitfolio.resume.dto;
 
 import com.be.gitfolio.common.type.PositionType;
+import com.be.gitfolio.common.type.Visibility;
 import com.be.gitfolio.resume.domain.Resume;
 import jakarta.validation.constraints.*;
 
@@ -29,7 +30,8 @@ public class ResumeRequestDTO {
 
     public record CreateResumeRequestDTO(
             @NotEmpty(message = "적어도 하나의 레포지토리를 선택해야 합니다.") List<String> selectedRepo,
-            String requirements
+            String requirements,
+            @NotBlank(message = "공개 여부는 필수 항목입니다.") Visibility visibility
     ) {}
 
     public record AIRequestDTO(

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
@@ -1,6 +1,7 @@
 package com.be.gitfolio.resume.dto;
 
 import com.be.gitfolio.common.type.PositionType;
+import com.be.gitfolio.common.type.Visibility;
 import com.be.gitfolio.resume.domain.Comment;
 import com.be.gitfolio.resume.domain.Resume;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,6 +14,9 @@ import java.util.List;
 
 public class ResumeResponseDTO {
 
+    public record UpdateVisibilityDTO(Visibility visibility) {}
+
+
     public record ResumeListDTO(
             String resumeId,
             Long memberId,
@@ -23,12 +27,13 @@ public class ResumeResponseDTO {
             int likeCount,
             int viewCount,
             LocalDateTime updatedAt,
-            @JsonProperty("isLiked") boolean liked
+            @JsonProperty("isLiked") boolean liked,
+            Visibility visibility
     ) {
         public ResumeListDTO(Resume resume, boolean liked, String avatarFullUrl) {
             this(
                     resume.getId(),
-                    Long.parseLong(resume.getMemberId()),
+                    resume.getMemberId(),
                     avatarFullUrl,
                     resume.getPosition(),
                     resume.getAboutMe(),
@@ -36,7 +41,8 @@ public class ResumeResponseDTO {
                     resume.getLikeCount(),
                     resume.getViewCount(),
                     resume.getUpdatedAt(),
-                    liked
+                    liked,
+                    resume.getVisibility()
             );
         }
     }
@@ -86,7 +92,8 @@ public class ResumeResponseDTO {
             int likeCount,
             int viewCount,
             @JsonProperty("isLiked") boolean liked,
-            LocalDateTime updatedAt
+            LocalDateTime updatedAt,
+            Visibility visibility
     ) {
         public ResumeDetailDTO(Resume resume, boolean liked, String avatarFullUrl) {
             this(
@@ -107,7 +114,8 @@ public class ResumeResponseDTO {
                     resume.getLikeCount(),
                     resume.getViewCount(),
                     liked,
-                    resume.getUpdatedAt()
+                    resume.getUpdatedAt(),
+                    resume.getVisibility()
             );
         }
     }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryImpl.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/repository/ResumeRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.be.gitfolio.resume.repository;
 
 import com.be.gitfolio.resume.domain.Resume;
-import com.be.gitfolio.resume.dto.ResumeRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,6 +13,8 @@ import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.List;
 
+import static com.be.gitfolio.resume.dto.ResumeRequestDTO.*;
+
 @RequiredArgsConstructor
 @Slf4j
 public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
@@ -21,8 +22,11 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public Page<Resume> findResumeByFilter(ResumeRequestDTO.ResumeFilterDTO resumeFilterDTO, List<String> likedResumeIds, Pageable pageable) {
+    public Page<Resume> findResumeByFilter(ResumeFilterDTO resumeFilterDTO, List<String> likedResumeIds, Pageable pageable) {
         Query query = new Query();
+
+        // 공개 여부 PUBLIC인 것만
+        query.addCriteria(Criteria.where("visibility").is("PUBLIC"));
 
         // 동적 필터 적용
         if (resumeFilterDTO.tag() != null && !resumeFilterDTO.tag().isEmpty()) {
@@ -58,6 +62,8 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
 
         // 페이징 처리
         query.with(pageable);
+        // allowDiskUse 옵션 추가
+        query.allowDiskUse(true);
         log.info("Generated Query : {}", query);
 
         // 결과 조회


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #70 

## 📝작업 내용

- 이력서 필드에 visibility를 추가했습니다.
- visibility는 "PUBLIC" / "PRIVATE" 두가지만 사용합니다.
- 이력서 생성 시 visibility를 body에 함께 보내야합니다.
- "/api/resumes/:resumeId/visibility" 엔드포인트에서 공개 여부를 변경할 수 있습니다.
- 이력서 조회 시 visibility 값을 응답 바디에 함께 담아서 전달합니다.

### 스크린샷 (선택)
<img width="1287" alt="스크린샷 2024-11-14 15 26 47" src="https://github.com/user-attachments/assets/41e515a4-62cf-41b2-9467-0ab7e2311801">
<img width="1297" alt="스크린샷 2024-11-14 15 26 58" src="https://github.com/user-attachments/assets/68d4d070-0b77-423e-9c4e-b9fcff135d96">

