### PR TITLE
🎨 이력서 상세조회 api 분리 및 결제모듈 로직 수정

### DIFF
--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/exception/ErrorCode.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
      */
     RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "이력서가 존재하지 않습니다."),
     INVALID_MEMBER_TO_UPDATE_RESUME(HttpStatus.FORBIDDEN, "이력서 작성자만 수정할 수 있습니다."),
+    RESUME_ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근할 수 없는 이력서 입니다."),
 
 
     /**

--- a/gitfolio-payment/src/main/java/com/be/gitfolio/payment/controller/PaymentController.java
+++ b/gitfolio-payment/src/main/java/com/be/gitfolio/payment/controller/PaymentController.java
@@ -5,10 +5,14 @@ import com.be.gitfolio.common.config.BaseResponse;
 import com.be.gitfolio.common.type.PaidPlan;
 import com.be.gitfolio.payment.service.PaymentService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 import static com.be.gitfolio.payment.dto.PaymentRequest.*;
 import static com.be.gitfolio.payment.dto.PaymentResponse.*;
@@ -19,6 +23,8 @@ import static com.be.gitfolio.payment.dto.PaymentResponse.*;
 @Slf4j
 public class PaymentController {
 
+    @Value("${payment.success.redirectUrl}")
+    private String paymentSuccessRedirectUrl;
     private final PaymentService paymentService;
 
     /**
@@ -36,9 +42,11 @@ public class PaymentController {
      * 결제 성공
      */
     @GetMapping("/success")
-    public ResponseEntity<BaseResponse<KakaoApproveResponse>> afterPayRequest(@RequestParam("pg_token") String pgToken,
-                                                                @RequestParam("member_id") Long memberId) {
-        return ResponseEntity.ok().body(new BaseResponse<>(paymentService.approveResponse(memberId, pgToken)));
+    public void afterPayRequest(@RequestParam("pg_token") String pgToken,
+                                @RequestParam("member_id") Long memberId,
+                                HttpServletResponse response) throws IOException {
+        paymentService.approveResponse(memberId, pgToken);
+        response.sendRedirect(paymentSuccessRedirectUrl);
     }
 
     /**

--- a/gitfolio-payment/src/main/resources/application.yml
+++ b/gitfolio-payment/src/main/resources/application.yml
@@ -61,6 +61,8 @@ kakaopay:
 payment:
   server:
     url: ${PAYMENT_SERVER_URL}
+  success:
+    redirectUrl: ${PAYMENT_SUCCESS_REDIRECT_URL}
 
 github:
   api:

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
@@ -43,7 +43,7 @@ public class ResumeController {
                 HttpStatus.CREATED,
                 "201 CREATED",
                 "이력서 생성에 성공했습니다.",
-                resumeService.createResume(memberId, createResumeRequestDTO, createResumeRequestDTO.visibility())
+                resumeService.createResume(memberId, createResumeRequestDTO)
         ));
     }
 
@@ -103,14 +103,14 @@ public class ResumeController {
     }
 
     /**
-     * 이력서 상세 조회
+     * 이력서 상세 조회(커뮤니티)
      */
-    @GetMapping("/{resumeId}")
-    public ResponseEntity<BaseResponse<ResumeDetailDTO>> getResumeDetail(@PathVariable("resumeId") String resumeId,
+    @GetMapping("/{resumeId}/community")
+    public ResponseEntity<BaseResponse<ResumeDetailDTO>> getCommunityResumeDetail(@PathVariable("resumeId") String resumeId,
                                                                          @RequestHeader(value = "Authorization", required = false) String token,
                                                                          HttpServletRequest request) {
         String clientIp = getClientIp(request);
-        return ResponseEntity.ok().body(new BaseResponse<>(resumeService.getResumeDetail(token, resumeId, clientIp)));
+        return ResponseEntity.ok().body(new BaseResponse<>(resumeService.getCommunityResumeDetail(token, resumeId, clientIp)));
     }
 
     // 클라이언트 IP 가져오는 유틸리티 메서드
@@ -120,6 +120,17 @@ public class ResumeController {
             ip = request.getRemoteAddr();
         }
         return ip;
+    }
+
+    /**
+     * 내 이력서 상세 조회(내 이력서)
+     */
+    @GetMapping("/{resumeId}/myResume")
+    public ResponseEntity<BaseResponse<ResumeDetailDTO>> getMyResumeDetail(@PathVariable("resumeId") String resumeId,
+                                                                         @RequestHeader(value = "Authorization", required = false) String token,
+                                                                         HttpServletRequest request) {
+        String clientIp = getClientIp(request);
+        return ResponseEntity.ok().body(new BaseResponse<>(resumeService.getMyResumeDetail(token, resumeId, clientIp)));
     }
 
     /**

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/domain/Resume.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/domain/Resume.java
@@ -4,6 +4,7 @@ import com.be.gitfolio.common.config.BaseEntityMongo;
 import com.be.gitfolio.common.type.*;
 import com.be.gitfolio.resume.dto.ResumeRequestDTO;
 import com.be.gitfolio.resume.dto.ResumeResponseDTO;
+import com.be.gitfolio.resume.type.Template;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.*;
@@ -42,6 +43,8 @@ public class Resume extends BaseEntityMongo {
     private Visibility visibility; // 공개 여부
     private int likeCount;  // 좋아요 수
     private int viewCount;  // 조회수
+    @Enumerated(EnumType.STRING)
+    private Template template;
 
     public void updateVisibility(Visibility visibility) {
         this.visibility = visibility;
@@ -63,7 +66,7 @@ public class Resume extends BaseEntityMongo {
         this.certificates = updateResumeDTO.certificates();
     }
 
-    public static Resume of(MemberInfoDTO memberInfoDTO, AIResponseDTO aiResponseDTO, Visibility visibility) {
+    public static Resume of(MemberInfoDTO memberInfoDTO, AIResponseDTO aiResponseDTO, CreateResumeRequestDTO createResumeRequestDTO) {
         return Resume.builder()
                 .memberId(String.valueOf(memberInfoDTO.memberId()))
                 .memberName(memberInfoDTO.name())
@@ -78,9 +81,10 @@ public class Resume extends BaseEntityMongo {
                 .links(memberInfoDTO.links())
                 .educations(memberInfoDTO.educations())
                 .certificates(memberInfoDTO.certificates())
-                .visibility(visibility)
+                .visibility(createResumeRequestDTO.visibility())
                 .likeCount(0)
                 .viewCount(0)
+                .template(createResumeRequestDTO.template())
                 .build();
     }
 

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeRequestDTO.java
@@ -4,6 +4,7 @@ import com.be.gitfolio.common.type.PaidPlan;
 import com.be.gitfolio.common.type.PositionType;
 import com.be.gitfolio.common.type.Visibility;
 import com.be.gitfolio.resume.domain.Resume;
+import com.be.gitfolio.resume.type.Template;
 import jakarta.validation.constraints.*;
 
 import java.util.List;
@@ -32,7 +33,8 @@ public class ResumeRequestDTO {
     public record CreateResumeRequestDTO(
             @NotEmpty(message = "적어도 하나의 레포지토리를 선택해야 합니다.") List<String> selectedRepo,
             String requirements,
-            @NotNull(message = "공개 여부는 필수 항목입니다.") Visibility visibility
+            @NotNull(message = "공개 여부는 필수 항목입니다.") Visibility visibility,
+            @NotNull(message = "템플릿 선택은 필수 항목입니다.") Template template
     ) {}
 
     public record UpdateResumeWithAIRequestDTO(

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/dto/ResumeResponseDTO.java
@@ -5,6 +5,7 @@ import com.be.gitfolio.common.type.Visibility;
 import com.be.gitfolio.common.utility.TimeUtils;
 import com.be.gitfolio.resume.domain.Comment;
 import com.be.gitfolio.resume.domain.Resume;
+import com.be.gitfolio.resume.type.Template;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -93,7 +94,8 @@ public class ResumeResponseDTO {
             int viewCount,
             @JsonProperty("isLiked") boolean liked,
             LocalDateTime updatedAt,
-            Visibility visibility
+            Visibility visibility,
+            Template template
     ) {
         public ResumeDetailDTO(Resume resume, boolean liked, String avatarFullUrl) {
             this(
@@ -115,7 +117,8 @@ public class ResumeResponseDTO {
                     resume.getViewCount(),
                     liked,
                     TimeUtils.convertUtcToSeoul(resume.getUpdatedAt()),
-                    resume.getVisibility()
+                    resume.getVisibility(),
+                    resume.getTemplate()
             );
         }
     }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/type/Template.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/type/Template.java
@@ -1,0 +1,5 @@
+package com.be.gitfolio.resume.type;
+
+public enum Template {
+    BASIC, STAR, GITFOLIO
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #91 

## 📝작업 내용

- 이력서 조회를 2개의 엔드포인트로 분리했습니다.
  1. 내 이력서 조회
  2. 커뮤니티 이력서 조회
- 이력서에 템플릿 필드를 추가했습니다.
- 결제 성공시 응답값이 아닌 특정 페이지로 리다이렉트 되도록 수정했습니다.

