### PR TITLE
🎨  spring batch 성능 최적화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,16 +5,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-docker-compose.yml
+docker-compose.local.yml
 
 ### KAFKA ###
-data/kafka1/
-data/kafka1/**/*
-data/kafka2/
-data/kafka2/**/*
-data/kafka3/
-data/kafka3/**/*
-data/zookeeper/**/*
+data/**/*
 
 ### STS ###
 .apt_generated

--- a/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
+++ b/gitfolio-auth/src/main/java/com/be/gitfolio/auth/controller/ReissueController.java
@@ -47,7 +47,7 @@ public class ReissueController {
 
         if (refresh == null) {
             //response status code
-            return new ResponseEntity<>("Refresh Token null", HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>("인증 정보가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         // Refresh 토큰 만료 확인
@@ -55,9 +55,9 @@ public class ReissueController {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
             //response status code
-            return new ResponseEntity<>("Refresh Token Expired", HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>("인증 정보가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
         } catch (SignatureException e) {
-            return new ResponseEntity<>("Refresh Signature Does Not Match", HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>("인증 정보가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
@@ -65,7 +65,7 @@ public class ReissueController {
 
         if (!category.equals("refresh")) {
             // response status code
-            return new ResponseEntity<>("Category is NOT Refresh", HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>("인증 정보가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         String username = jwtUtil.getUsername(refresh);
@@ -75,7 +75,7 @@ public class ReissueController {
 
         // Redis에서 토큰 존재 여부 확인
         if (!redisTokenRepository.existsByRefreshToken(username)) {
-            return new ResponseEntity<>("Token is NOT in Redis", HttpStatus.UNAUTHORIZED);
+            return new ResponseEntity<>("인증 정보가 만료되었습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         // make new JWT

--- a/gitfolio-common/src/main/java/com/be/gitfolio/common/event/KafkaEvent.java
+++ b/gitfolio-common/src/main/java/com/be/gitfolio/common/event/KafkaEvent.java
@@ -24,4 +24,12 @@ public class KafkaEvent {
     public static class ExpirationEvent {
         private Long memberId;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MemberDeletedEvent {
+        private Long memberId;
+    }
 }

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/config/MemberBatchConfig.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/config/MemberBatchConfig.java
@@ -1,8 +1,8 @@
 package com.be.gitfolio.member.config;
 
 import com.be.gitfolio.common.type.PaidPlan;
+import com.be.gitfolio.common.type.PositionType;
 import com.be.gitfolio.member.infrastructure.member.MemberEntity;
-import com.be.gitfolio.member.infrastructure.member.MemberJpaRepository;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -12,14 +12,23 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.batch.item.data.RepositoryItemWriter;
-import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
-import org.springframework.batch.item.database.JpaCursorItemReader;
-import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
@@ -29,7 +38,7 @@ public class MemberBatchConfig {
 
     private final JobRepository jobRepository;
     private final EntityManagerFactory entityManagerFactory;
-    private final MemberJpaRepository memberRepository;
+    private final DataSource dataSource;
 
     @Bean
     public Job remainingCountResetJob(Step remainingCountResetStep) {
@@ -41,21 +50,80 @@ public class MemberBatchConfig {
     @Bean
     public Step remainingCountResetStep(PlatformTransactionManager transactionManager) {
         return new StepBuilder("remainingCount", jobRepository)
-                .<MemberEntity, MemberEntity>chunk(100, transactionManager)
+                .<MemberEntity, MemberEntity>chunk(500, transactionManager)
                 .reader(freeMemberItemReader())
                 .processor(freeMemberItemProcessor())
                 .writer(freeMemberItemWriter())
+                .taskExecutor(taskExecutor())
+                .faultTolerant()
+                .retryLimit(10)
+                .retry(SQLException.class)
+                .retry(IOException.class)
+                .backOffPolicy(new FixedBackOffPolicy() {{
+                    setBackOffPeriod(2000); // 재시도 간격 2초
+                }})
                 .build();
     }
 
     @Bean
-    public JpaCursorItemReader<MemberEntity> freeMemberItemReader() {
-        return new JpaCursorItemReaderBuilder<MemberEntity>()
-                .name("freeMemberItemReader")
-                .entityManagerFactory(entityManagerFactory)
-                .queryString("SELECT m FROM MemberEntity m WHERE m.paidPlan = :paidPlan ORDER BY m.id ASC")
-                .parameterValues(Map.of("paidPlan", PaidPlan.FREE))
-                .build();
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(2);    // 최소 스레드 수
+        taskExecutor.setMaxPoolSize(4);    // 최대 스레드 수
+        taskExecutor.setQueueCapacity(100); // 대기열 용량
+        taskExecutor.setThreadNamePrefix("Batch-Thread-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+
+    // JDBC 기반 PagingItemReader 설정
+    @Bean
+    public JdbcPagingItemReader<MemberEntity> freeMemberItemReader() {
+        JdbcPagingItemReader<MemberEntity> reader = new JdbcPagingItemReader<>();
+        reader.setDataSource(dataSource);
+        reader.setFetchSize(500);
+        reader.setRowMapper(new MemberRowMapper()); // 커스텀 RowMapper 설정
+
+        Map<String, Object> parameterValues = new HashMap<>();
+        parameterValues.put("paidPlan", PaidPlan.FREE.name());
+        reader.setParameterValues(parameterValues);
+
+        try {
+            SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+            queryProvider.setDataSource(dataSource);
+            queryProvider.setSelectClause("SELECT *");
+            queryProvider.setFromClause("FROM member"); // 실제 테이블 이름 확인
+            queryProvider.setWhereClause("WHERE paid_plan = :paidPlan");
+            queryProvider.setSortKey("member_id"); // 고유한 정렬 키 사용 (테이블의 PK)
+            reader.setQueryProvider(queryProvider.getObject());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create query provider for JdbcPagingItemReader", e);
+        }
+
+        return reader;
+    }
+
+    // 커스텀 RowMapper 구현
+    public static class MemberRowMapper implements RowMapper<MemberEntity> {
+        @Override
+        public MemberEntity mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return MemberEntity.builder()
+                    .id(rs.getLong("member_id")) // @Column(name = "member_id")
+                    .username(rs.getString("username"))
+                    .nickname(rs.getString("nickname"))
+                    .name(rs.getString("name"))
+                    .githubName(rs.getString("github_name"))
+                    .role(rs.getString("role"))
+                    .avatarUrl(rs.getString("avatar_url"))
+                    .phoneNumber(rs.getString("phone_number"))
+                    .email(rs.getString("email"))
+                    .position(PositionType.valueOf(rs.getString("position"))) // Enum 매핑
+                    .paidPlan(PaidPlan.valueOf(rs.getString("paid_plan"))) // Enum 매핑
+                    .remainingCount(rs.getInt("remaining_count"))
+                    .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                    .updatedAt(rs.getTimestamp("updated_at").toLocalDateTime())
+                    .build();
+        }
     }
 
     @Bean
@@ -67,11 +135,15 @@ public class MemberBatchConfig {
         };
     }
 
+    // JDBC 기반 Writer 설정: 잔여 카운트 업데이트
     @Bean
-    public RepositoryItemWriter<MemberEntity> freeMemberItemWriter() {
-        return new RepositoryItemWriterBuilder<MemberEntity>()
-                .repository(memberRepository)
-                .methodName("save")
-                .build();
+    public JdbcBatchItemWriter<MemberEntity> freeMemberItemWriter() {
+        JdbcBatchItemWriter<MemberEntity> writer = new JdbcBatchItemWriter<>();
+        writer.setDataSource(dataSource);
+        writer.setSql("UPDATE member SET remaining_count = :remainingCount WHERE member_id = :id");
+        writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());
+        writer.setAssertUpdates(false); // 업데이트된 행이 없더라도 예외를 발생시키지 않음
+
+        return writer;
     }
 }

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/domain/Member.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/domain/Member.java
@@ -65,9 +65,13 @@ public class Member {
     }
 
     public Member decreaseRemainingCount() {
-        return this.toBuilder()
-                .remainingCount(remainingCount-1)
-                .updatedAt(LocalDateTime.now())
-                .build();
+        if (this.paidPlan.equals(PaidPlan.FREE)) {
+            return this.toBuilder()
+                    .remainingCount(remainingCount - 1)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+        } else {
+            return this;
+        }
     }
 }

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/event/MemberEventPublisher.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/event/MemberEventPublisher.java
@@ -1,0 +1,22 @@
+package com.be.gitfolio.member.event;
+
+import com.be.gitfolio.common.event.KafkaEvent;
+import com.be.gitfolio.common.type.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.be.gitfolio.common.event.KafkaEvent.*;
+
+@Component
+@RequiredArgsConstructor
+public class MemberEventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    // 댓글 및 좋아요 이벤트 발행
+    public void publishResumeEvent(Long memberId) {
+        MemberDeletedEvent event = MemberDeletedEvent.builder().memberId(memberId).build();
+        kafkaTemplate.send("memberDeletedEventTopic", event);
+    }
+}

--- a/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberServiceImpl.java
+++ b/gitfolio-member/src/main/java/com/be/gitfolio/member/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import com.be.gitfolio.member.controller.port.MemberService;
 import com.be.gitfolio.member.domain.Member;
 import com.be.gitfolio.member.domain.MemberAdditionalInfo;
 import com.be.gitfolio.member.domain.request.MemberAdditionalInfoRequest.MemberAdditionalInfoUpdate;
+import com.be.gitfolio.member.event.MemberEventPublisher;
 import com.be.gitfolio.member.service.port.GithubClient;
 import com.be.gitfolio.member.service.port.MemberAdditionalInfoRepository;
 import com.be.gitfolio.member.service.port.MemberRepository;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 
+import static com.be.gitfolio.common.event.KafkaEvent.*;
 import static com.be.gitfolio.member.domain.request.MemberRequest.*;
 import static com.be.gitfolio.member.controller.response.MemberResponse.*;
 
@@ -52,6 +54,7 @@ public class MemberServiceImpl implements MemberService {
     private final JobLauncher jobLauncher;
     private final Job remainingCountResetJob;
     private final JobRepository jobRepository;
+    private final MemberEventPublisher memberEventPublisher;
 
     /**
      * 회원 생성
@@ -101,6 +104,7 @@ public class MemberServiceImpl implements MemberService {
     /**
      * 회원 정보 상세 조회
      */
+    @Override
     public MemberDetail getMemberDetails(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NO_MEMBER_INFO));
@@ -204,6 +208,7 @@ public class MemberServiceImpl implements MemberService {
     public void deleteMember(Long memberId) {
         memberRepository.deleteById(memberId);
         memberAdditionalInfoRepository.deleteByMemberId(memberId);
+        memberEventPublisher.publishResumeEvent(memberId);
     }
 
     /**
@@ -227,7 +232,7 @@ public class MemberServiceImpl implements MemberService {
      */
     @KafkaListener(topics = "expiration-topic", groupId = "member-service-group")
     @Transactional
-    public void handleExpirationEvent(KafkaEvent.ExpirationEvent event) {
+    public void handleExpirationEvent(ExpirationEvent event) {
         Long memberId = event.getMemberId();
         Optional<Member> memberOpt = memberRepository.findById(memberId);
 

--- a/gitfolio-member/src/main/resources/application.yml
+++ b/gitfolio-member/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     import: optional:file:.env[.properties]
   data:
     mongodb:
-      uri: mongodb://${MEMBER_MONGO_DB_USERNAME}:${MEMBER_MONGO_DB_PORT}/${MEMBER_MONGO_DB_DATABASE}
+      uri: ${MEMBER_MONGO_DB_URI}
     redis:
       host: ${RESUME_REDIS_HOST}
       port: ${RESUME_REDIS_PORT}
@@ -23,6 +23,11 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_HOST1}:${KAFKA_PORT1}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.trusted.packages: "*"
     consumer:
       group-id: member-group
       auto-offset-reset: earliest

--- a/gitfolio-notification/src/main/java/com/be/gitfolio/notification/repository/NotificationJpaRepository.java
+++ b/gitfolio-notification/src/main/java/com/be/gitfolio/notification/repository/NotificationJpaRepository.java
@@ -2,11 +2,16 @@ package com.be.gitfolio.notification.repository;
 
 import com.be.gitfolio.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByReceiverIdAndReadFalse(Long receiverId);
 
-
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.senderId = :memberId OR n.receiverId = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/gitfolio-notification/src/main/java/com/be/gitfolio/notification/repository/NotificationRepositoryImpl.java
+++ b/gitfolio-notification/src/main/java/com/be/gitfolio/notification/repository/NotificationRepositoryImpl.java
@@ -28,4 +28,9 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     public List<Notification> findAllByReceiverIdAndReadFalse(Long receiverId) {
         return notificationJpaRepository.findAllByReceiverIdAndReadFalse(receiverId);
     }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        notificationJpaRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/gitfolio-notification/src/main/java/com/be/gitfolio/notification/service/NotificationService.java
+++ b/gitfolio-notification/src/main/java/com/be/gitfolio/notification/service/NotificationService.java
@@ -42,6 +42,18 @@ public class NotificationService {
     }
 
     /**
+     * 회원 탈퇴 이벤트 핸들러
+     * @param event
+     */
+    @Transactional
+    @KafkaListener(topics = "memberDeletedEventTopic", groupId = "notification-group")
+    public void memberDeleteEventHandler(MemberDeletedEvent event) {
+        Long memberId = event.getMemberId();
+        log.info("Kafka 메시지 도착 : {}", memberId);
+        notificationRepository.deleteAllByMemberId(memberId);
+    }
+
+    /**
      * 내 알림 전체 조회
      * @param receiverId
      * @return List<NotificationListDTO>

--- a/gitfolio-notification/src/main/java/com/be/gitfolio/notification/service/port/NotificationRepository.java
+++ b/gitfolio-notification/src/main/java/com/be/gitfolio/notification/service/port/NotificationRepository.java
@@ -11,4 +11,6 @@ public interface NotificationRepository {
     Optional<Notification> findById(Long notificationId);
 
     List<Notification> findAllByReceiverIdAndReadFalse(Long receiverId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-payment/src/main/java/com/be/gitfolio/payment/infrastructure/PaymentRepository.java
+++ b/gitfolio-payment/src/main/java/com/be/gitfolio/payment/infrastructure/PaymentRepository.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByTransactionId(String transactionId);
     Optional<Payment> findByMemberIdAndPaidPlan(Long memberId, PaidPlan paidPlan);
-
     Optional<Payment> findByMemberId(Long memberId);
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-payment/src/main/java/com/be/gitfolio/payment/schedule/PaymentBatchScheduler.java
+++ b/gitfolio-payment/src/main/java/com/be/gitfolio/payment/schedule/PaymentBatchScheduler.java
@@ -19,7 +19,7 @@ public class PaymentBatchScheduler {
     private final JobLauncher jobLauncher;
     private final Job paymentExpirationJob;
 
-    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    @Scheduled(cron = "0 55 15 * * *") // 매일 자정에 실행
     public void runPaymentExpirationJob() throws Exception {
         log.info("Payment Job Start");
 

--- a/gitfolio-payment/src/main/java/com/be/gitfolio/payment/schedule/PaymentBatchScheduler.java
+++ b/gitfolio-payment/src/main/java/com/be/gitfolio/payment/schedule/PaymentBatchScheduler.java
@@ -19,7 +19,7 @@ public class PaymentBatchScheduler {
     private final JobLauncher jobLauncher;
     private final Job paymentExpirationJob;
 
-    @Scheduled(cron = "0 55 15 * * *") // 매일 자정에 실행
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     public void runPaymentExpirationJob() throws Exception {
         log.info("Payment Job Start");
 

--- a/gitfolio-payment/src/main/resources/application.yml
+++ b/gitfolio-payment/src/main/resources/application.yml
@@ -32,6 +32,13 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.trusted.packages: "*"
+    consumer:
+      group-id: payment-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
 
   jwt:
     secret: ${JWT_SECRET_KEY}

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/controller/ResumeController.java
@@ -160,12 +160,13 @@ public class ResumeController {
     @AuthRequired
     @PutMapping("/{resumeId}")
     public ResponseEntity<BaseResponse<String>> updateResume(HttpServletRequest request,
+                                                             @RequestParam(value = "isAiFixed", required = false) Boolean isAiFixed,
                                                              @PathVariable("resumeId") String resumeId,
                                                              @RequestPart("updateResumeRequestDTO") UpdateResumeRequestDTO updateResumeRequestDTO,
                                                              @RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
 
         String memberId = request.getAttribute("memberId").toString();
-        resumeService.updateResume(Long.valueOf(memberId), resumeId, updateResumeRequestDTO, imageFile);
+        resumeService.updateResume(Long.valueOf(memberId), resumeId, updateResumeRequestDTO, imageFile, isAiFixed);
         return ResponseEntity.ok().body(new BaseResponse<>("이력서 수정이 완료되었습니다."));
     }
 

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/comment/CommentJpaRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/comment/CommentJpaRepository.java
@@ -11,4 +11,6 @@ public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByResumeId(String resumeId);
 
     void deleteCommentsByResumeId(String resumeId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/comment/CommentRepositoryImpl.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/comment/CommentRepositoryImpl.java
@@ -38,4 +38,9 @@ public class CommentRepositoryImpl implements CommentRepository {
     public void deleteCommentsByResumeId(String resumeId) {
         commentJpaRepository.deleteCommentsByResumeId(resumeId);
     }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        commentJpaRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/like/LikeJpaRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/like/LikeJpaRepository.java
@@ -26,4 +26,6 @@ public interface LikeJpaRepository extends JpaRepository<Like, Long> {
 
     @Query("SELECT l.resumeId FROM Like l WHERE l.memberId = :memberId AND l.resumeId IN :resumeIds")
     List<String> findLikedResumeIdsByMemberIdAndResumeIds(Long memberId, List<String> resumeIds);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/like/LikeRepositoryImpl.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/like/LikeRepositoryImpl.java
@@ -53,4 +53,9 @@ public class LikeRepositoryImpl implements LikeRepository {
     public Like save(Like like) {
         return likeJpaRepository.save(like);
     }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        likeJpaRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/resume/ResumeMongoRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/resume/ResumeMongoRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface ResumeMongoRepository extends MongoRepository<Resume, String> {
 
     Page<Resume> findAllByMemberId(Long memberId, Pageable pageable);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/resume/ResumeRepositoryImpl.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/infrastructure/resume/ResumeRepositoryImpl.java
@@ -91,4 +91,9 @@ public class ResumeRepositoryImpl implements ResumeRepository {
     public void deleteById(String resumeId) {
         resumeMongoRepository.deleteById(resumeId);
     }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        resumeMongoRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/CommentRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/CommentRepository.java
@@ -15,4 +15,6 @@ public interface CommentRepository {
     List<Comment> findAllByResumeId(String resumeId);
 
     void deleteCommentsByResumeId(String resumeId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/LikeRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/LikeRepository.java
@@ -21,4 +21,6 @@ public interface LikeRepository {
     void deleteByResumeIdAndMemberId(String resumeId, Long memberId);
 
     Like save(Like like);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/ResumeRepository.java
+++ b/gitfolio-resume/src/main/java/com/be/gitfolio/resume/service/port/ResumeRepository.java
@@ -20,4 +20,6 @@ public interface ResumeRepository {
     Page<Resume> findAllByMemberId(Long memberId, Pageable pageable);
 
     void deleteById(String resumeId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/gitfolio-resume/src/main/resources/application.yml
+++ b/gitfolio-resume/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     import: optional:file:.env[.properties]
   data:
     mongodb:
-      uri: mongodb://${RESUME_MONGO_DB_USERNAME}:${RESUME_MONGO_DB_PORT}/${RESUME_MONGO_DB_DATABASE}
+      uri: ${RESUME_MONGO_DB_URI}
     redis:
       host: ${RESUME_REDIS_HOST}
       port: ${RESUME_REDIS_PORT}
@@ -30,6 +30,13 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: resume-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
 
   jwt:
     secret: ${JWT_SECRET_KEY}

--- a/gitfolio-resume/src/test/java/com/be/gitfolio/resume/mock/FakeResumeRepository.java
+++ b/gitfolio-resume/src/test/java/com/be/gitfolio/resume/mock/FakeResumeRepository.java
@@ -106,4 +106,9 @@ public class FakeResumeRepository implements ResumeRepository {
     public void deleteById(String resumeId) {
         data.removeIf(item -> Objects.equals(item.getId(), resumeId));
     }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        data.removeIf(item -> Objects.equals(item.getMemberId(), memberId));
+    }
 }

--- a/gitfolio-resume/src/test/java/com/be/gitfolio/resume/service/ResumeServiceTest.java
+++ b/gitfolio-resume/src/test/java/com/be/gitfolio/resume/service/ResumeServiceTest.java
@@ -632,7 +632,7 @@ public class ResumeServiceTest {
         Mockito.when(s3Service.uploadFile(any())).thenReturn("updatedAvatarUrl");
 
         //when
-        resumeService.updateResume(1L, "testResume123", updateResumeRequestDTO, imageFile);
+        resumeService.updateResume(1L, "testResume123", updateResumeRequestDTO, imageFile, isAiFixed);
 
         //then
         Optional<Resume> resume = resumeRepository.findById("testResume123");
@@ -652,7 +652,7 @@ public class ResumeServiceTest {
         //when
         //then
         assertThatThrownBy(() -> {
-            resumeService.updateResume(2L, "testResume123", updateResumeRequestDTO, imageFile);
+            resumeService.updateResume(2L, "testResume123", updateResumeRequestDTO, imageFile, isAiFixed);
         }).isInstanceOf(BaseException.class);
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #104 
- close #105 

## 📝작업 내용

- refresh 토큰의 validation시 에러 메시지를 사용자 친화적으로 변경했습니다.
- 회원 탈퇴기능을 구현했습니다.
- 회원 탈퇴시 Member모듈에서 탈퇴 이벤트를 produce하면 각 모듈에서 해당 이벤트를 consume해서 해당 회원 관련 데이터를 전부 삭제하게 됩니다.
- 사용권 감소 로직을 AI수정 요청 시 처리하는 것이 아니라 AI 수정 내용을 이력서 직접 수정 API에 요청할때 isAiFixed=true를 쿼리 파라미터로 담아서 보내면 이력서 수정을 완료하고 사용권이 감소되도록 변경했습니다.
- Spring Batch의 성능을 최적화하기 위해 병렬 처리 및 JPA -> JDBC로 변경해 처리 시간을 약 84% 감소시켰습니다.

### 스크린샷
<img width="742" alt="스크린샷 2024-12-17 15 33 20" src="https://github.com/user-attachments/assets/5e85ecc8-03bc-4345-92d8-6aec6f13fdec" />

